### PR TITLE
Add ability to do base network configuration as part of the OS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+template-library-os
+===================
+
+Template library for configuring OS.
+
+This repository contains one branch for each OS version. OS versions with '-spma' suffix are intended for deployment by
+SPMA-based ncm-spma. Those without the suffix are intended to be deployed with the YUM-based ncm-spma (v3 and later).
+
+This branch, sl5.x, delivers templates that can be used to deploy any RHEL/CENTOS/SL5 version. When using other parts of the template
+library, to use these templates you need to define the following variable:
+
+variable OS_FLAVOUR_ENABLED ?= true;
+
+You also need to define the actual OS version to deploy using variable OS_VERSION, as with previous generation
+of OS templates.
+
+In addition if you use YUM snapshot (you should!), you probably want to define the following variables, changing the
+values to what is appropriate for your site (see http://quattor.github.com//documentation/2014/03/24/spma-yum-migration.html):
+
+variable YUM_SNAPSHOT_DATE ?= '20140304';
+variable AII_OSINSTALL_ROOT = '/yum/snapshots/'+YUM_SNAPSHOT_DATE;
+
+OS base configuration now includes by default network configuration, using the standard network configuration
+implemented by os/network/config from template-library-standard. To disable this standard network configuration,
+define variable OS_BASE_CONFIGURE_NETWORK to false. Note that in this case, you must provide the network
+configuration as part of the site-specific configuration.
+

--- a/config/core/base.pan
+++ b/config/core/base.pan
@@ -2,6 +2,14 @@ unique template config/core/base;
 
 variable USE_OFED ?= false;
 
+@{
+desc =  if true, standard network configuration is done as part of the base OS configuration.\
+ if false, network configuration must be done as part of the site-specific configuration.
+values = true or false
+default = true
+required = no
+}
+variable OS_BASE_CONFIGURE_NETWORK ?= true;
 variable OS_CORE_ONLY ?= false;
 variable SITE_ADDITIONAL_PACKAGES ?= undef;
 
@@ -45,7 +53,11 @@ include { if ( is_defined(SITE_ADDITIONAL_PACKAGES) ) if_exists(SITE_ADDITIONAL_
 include {'config/core/daemons'};
 include { 'config/core/boot'};
 
+# Configure network, except if disabled
+variable DEBUG = debug(format('%s: OS_BASE_CONFIGURE_NETWORK=%s',OBJECT,to_string(OS_BASE_CONFIGURE_NETWORK)));
+include { if ( OS_BASE_CONFIGURE_NETWORK ) 'os/network/config' };
 
 # Local site OS configuration
+variable DEBUG = debug(format('%s: OS_BASE_CONFIG_SITE=%s',OBJECT,to_string(OS_BASE_CONFIG_SITE)));
 include { OS_BASE_CONFIG_SITE };
 


### PR DESCRIPTION
- Controled with variable OS_BASE_CONFIGURE_NETWORK
- enabled by default

Requires https://github.com/quattor/template-library-standard/pull/21.
