### PR TITLE
sl6.x: fix iSCSI configuration as part of base OS

### DIFF
--- a/config/core/base.pan
+++ b/config/core/base.pan
@@ -47,5 +47,6 @@ include { 'config/core/boot'};
 
 
 # Local site OS configuration
+variable DEBUG = debug(format('%s: OS_BASE_CONFIG_SITE=%s',OBJECT,to_string(OS_BASE_CONFIG_SITE)));
 include { OS_BASE_CONFIG_SITE };
 

--- a/config/core/daemons.pan
+++ b/config/core/daemons.pan
@@ -5,19 +5,46 @@
 
 unique template config/core/daemons;
 
-variable OS_WANTED_DEFAULT_DAEMONS ?= list (
-    "sshd",
-);
+variable OS_WANTED_DEFAULT_DAEMONS ?= {
+  append('sshd');
+  if ( ! OS_CORE_ONLY && OS_CORE_ISCSI_ENABLED ) {
+    # Start only iscsi service, iscsid will be started automatically when needed
+    append('iscsi');
+  };
+  SELF;
+};
 
-variable OS_UNWANTED_DEFAULT_DAEMONS ?= list (
-    "yum", "yum-updatesd", "avahi-daemon",
-    "hplip", "pcscd", "gpm", "ipsec",
-    "bluetooth", "cups", "iscsi","iscsid",
-    "isdn","jexec", 'yum-cron','tog-pegasus',
-    "wpa_supplicant","pppoe-server","postfix",
-    "portreserve","haldaemon","NetworkManager",
-    "abrt","kdump","rhsmcertd", "stap-server",
-);
+variable OS_UNWANTED_DEFAULT_DAEMONS ?= {
+  append('abrt');
+  append('avahi-daemon');
+  append('bluetooth');
+  append('cups');
+  append('hplip');
+  append('gpm');
+  append('haldaemon');
+  append('ipsec');
+  append('iscsid');
+  append('isdn');
+  append('jexec'); 
+  append('kdump');
+  append('NetworkManager');
+  append('pcscd');
+  append('postfix');
+  append('portreserve');
+  append('pppoe-server');
+  append('rhsmcertd'); 
+  append('stap-server');
+  append('tog-pegasus');
+  append('wpa_supplicant');
+  append('yum'); 
+  append('yum-cron');
+  append('yum-updatesd');
+  if ( OS_CORE_ONLY || ! OS_CORE_ISCSI_ENABLED ) {
+    append('iscsi');
+    append('iscsid');
+  };
+  SELF;
+};
 
 "/software/components/chkconfig/service/" = {
 	foreach(k;v;OS_WANTED_DEFAULT_DAEMONS) {


### PR DESCRIPTION
Previous version was properly adding the required RPM but forgetting to start the iscsi service when OS_BASE_ISCSI_ENABLED was true.
