### PR TITLE
OS_VERSION_PARAMS: define 'family' key as 'el' (common to all RH derivatives

### DIFF
--- a/config/core/base.pan
+++ b/config/core/base.pan
@@ -15,6 +15,7 @@ variable SITE_ADDITIONAL_PACKAGES ?= undef;
 # Default if not properly defined elsewhere, using the standard mechanism
 variable OS_VERSION_PARAMS ?= nlist(
     "distribution", "el",
+    "family",       "el",
     "major",        "el7",
     "majorversion", "7",
     "minor",        "x",


### PR DESCRIPTION
Ensure a default appropriate for https://github.com/quattor/template-library-standard/pull/48.