### PR TITLE
El7 support: ensure that kernel RPM is part of the configuration

### DIFF
--- a/rpms/base.pan
+++ b/rpms/base.pan
@@ -26,6 +26,12 @@ variable OS_CORE_RDMA_ENABLED ?= false;
 # Additional packages
 
 '/software/packages' = {
+  # Add kernel RPM explicitly to ensure that it is part of the configuration as it is
+  # not a dependency for any package in YUM group core.
+  # Without it, there is the risk that the initial kernel will never been upgraded as
+  # ncm-spma will keep trying removing all kernels and only the running one will be kept.
+  pkg_repl('kernel');
+
   # grub2 doesn't seem to be part of core or base group...
   pkg_repl('grub2');
 

--- a/rpms/development-base-tools.pan
+++ b/rpms/development-base-tools.pan
@@ -33,6 +33,7 @@ prefix '/software/packages';
 
 # Python
 '{python-devel}' ?= nlist();
+'{python-pip}' ?= nlist();
 
 # XML
 '{expat-devel}' ?= nlist();

--- a/rpms/quattor-development.pan
+++ b/rpms/quattor-development.pan
@@ -18,6 +18,9 @@ prefix '/software/packages';
 '{perl-Config-Properties}' = nlist();
 '{perl-Config-Tiny}' = nlist();
 '{perl-File-Copy-Recursive}' = nlist();
+'{perl-CDB_File}' = nlist();
+'{perl-Taint-Runtime}' = nlist();
+'{perl-enum}' = nlist();
 
 '{rpmdevtools}' = nlist();
 


### PR DESCRIPTION
This PR fixes an important problem in EL7 default config that results in the kernel not being upgraded (see comment in `rpms/base.pan`). It also adds Python pip on development machines where Python is installed (almost a requirement for adding Python modules nowadays).

Due to severe issue fixed, I'd appreciate if this PR could make it into [15.2](https://github.com/quattor/release/issues/236)...