### PR TITLE
iscsid daemon

### DIFF
--- a/config/core/daemons.pan
+++ b/config/core/daemons.pan
@@ -23,7 +23,6 @@ variable OS_UNWANTED_DEFAULT_DAEMONS ?= {
   append('gpm');
   append('haldaemon');
   append('ipsec');
-  append('iscsid');
   append('isdn');
   append('jexec');
   append('kdump');


### PR DESCRIPTION
let the daemon iscsid to start if the variable OS_CORE_ISCSI_ENABLED is set to true