### PR TITLE
Ensure that state of iptables and firewalld services are consistently defined

### DIFF
--- a/config/core/base.pan
+++ b/config/core/base.pan
@@ -70,7 +70,7 @@ variable KERNEL_FIRMWARE_ARCH ?= "noarch";
 #
 # Kernel version and CPU architecture
 #
-include { 'os/kernel_version_arch' };
+include 'os/kernel_version_arch';
 
 # Default architecture to use for packages, if several architectures are
 # supported for a service.
@@ -79,16 +79,16 @@ include { 'os/kernel_version_arch' };
 variable PKG_ARCH_BASE ?= PKG_ARCH_DEFAULT;
 
 # Minimum list of packages
-include {'rpms/base' };
-include { if ( is_defined(SITE_ADDITIONAL_PACKAGES) ) if_exists(SITE_ADDITIONAL_PACKAGES) };
+include 'rpms/base';
+include if ( is_defined(SITE_ADDITIONAL_PACKAGES) ) if_exists(SITE_ADDITIONAL_PACKAGES);
 
 # core extras
-include {'config/core/daemons'};
-include { 'config/core/boot'};
+include 'config/core/daemons';
+include 'config/core/boot';
 
 # Configure network, except if disabled
 variable DEBUG = debug(format('%s: OS_BASE_CONFIGURE_NETWORK=%s',OBJECT,to_string(OS_BASE_CONFIGURE_NETWORK)));
-include { if ( OS_BASE_CONFIGURE_NETWORK ) 'os/network/config' };
+include if ( OS_BASE_CONFIGURE_NETWORK ) 'os/network/config';
 
 # Install/enable iptables services if needed
 include if ( OS_USE_IPTABLES_SERVICES ) 'config/core/iptables-services';
@@ -129,5 +129,5 @@ prefix '/software/components/accounts';
 
 # Local site OS configuration
 variable DEBUG = debug(format('%s: OS_BASE_CONFIG_SITE=%s',OBJECT,to_string(OS_BASE_CONFIG_SITE)));
-include { OS_BASE_CONFIG_SITE };
+include OS_BASE_CONFIG_SITE;
 

--- a/config/core/base.pan
+++ b/config/core/base.pan
@@ -55,6 +55,14 @@ variable YUM_OS_DISTRIBUTION_NAME ?= {
   };
 };
 
+@{
+desc = use iptables and ip6tables services instead of firewalld
+value = true or false
+default = false (EL7 default is to use firewalld)
+required = no
+}
+variable OS_USE_IPTABLES_SERVICES ?= false;
+
 
 variable OS_BASE_CONFIG_SITE ?= null;
 
@@ -82,6 +90,9 @@ include { 'config/core/boot'};
 variable DEBUG = debug(format('%s: OS_BASE_CONFIGURE_NETWORK=%s',OBJECT,to_string(OS_BASE_CONFIGURE_NETWORK)));
 include { if ( OS_BASE_CONFIGURE_NETWORK ) 'os/network/config' };
 
+# Install/enable iptables services if needed
+include if ( OS_USE_IPTABLES_SERVICES ) 'config/core/iptables-services';
+
 # Use ncm-systemd instead of ncm-chkconfig to process ncm-chkconfig configuration
 include 'components/systemd/legacy/chkconfig';
 
@@ -90,6 +101,7 @@ include 'components/systemd/legacy/chkconfig';
 # Users and groups are those added by systemd and polkit RPMs
 include 'components/accounts/config';
 prefix '/software/components/accounts';
+'kept_users/centos' = '';
 'kept_users/chrony' = '';
 'kept_users/libstoragemgmt' = '';
 'kept_users/polkitd' = '';
@@ -97,19 +109,23 @@ prefix '/software/components/accounts';
 'kept_users/systemd-bus-proxy' = '';
 'kept_users/systemd-network' = '';
 'kept_users/unbound' = '';
+'kept_groups/centos' = '';
 'kept_groups/libstoragemgmt' = '';
 'kept_groups/polkitd' = '';
 'kept_groups/ssh_keys' = '';
 'kept_groups/cdrom' = '';
+'kept_groups/cgred' = '';
 'kept_groups/chrony' = '';
 'kept_groups/dialout' = '';
 'kept_groups/floppy' = '';
+'kept_groups/input' = '';
 'kept_groups/systemd-bus-proxy' = '';
 'kept_groups/systemd-journal' = '';
 'kept_groups/systemd-network' = '';
 'kept_groups/tape' = '';
 'kept_groups/unbound' = '';
 'kept_groups/utmp' = '';
+'kept_groups/wireshark' = '';
 
 # Local site OS configuration
 variable DEBUG = debug(format('%s: OS_BASE_CONFIG_SITE=%s',OBJECT,to_string(OS_BASE_CONFIG_SITE)));

--- a/config/core/firewalld.pan
+++ b/config/core/firewalld.pan
@@ -1,0 +1,13 @@
+unique template config/core/firewalld;
+
+
+# Disable firewalld
+prefix '/software/components/systemd/unit/firewalld';
+'state' = if ( OS_DISABLE_FIREWALLD ) {
+            'disabled';
+          } else {
+            'enabled';
+          };
+'startstop' = true;
+
+

--- a/config/core/iptables-services.pan
+++ b/config/core/iptables-services.pan
@@ -1,0 +1,22 @@
+unique template config/core/iptables-services;
+
+# Install package providing iptables and ip6tables services
+'/software/packages' = {
+  pkg_repl('iptables-services');
+
+  SELF;
+};
+
+# Disable firewalld
+prefix '/software/components/systemd/unit/firewalld';
+'state' = 'masked';
+'startstop' = true;
+
+
+# Enable iptables and ip6tables
+prefix '/software/components/systemd/unit/iptables';
+'state' = 'enabled';
+'startstop' = true;
+prefix '/software/components/systemd/unit/ip6tables';
+'state' = 'enabled';
+'startstop' = true;

--- a/config/core/iptables-services.pan
+++ b/config/core/iptables-services.pan
@@ -7,7 +7,7 @@ unique template config/core/iptables-services;
   SELF;
 };
 
-# Disable firewalld
+# Disable and mask firewalld
 prefix '/software/components/systemd/unit/firewalld';
 'state' = 'masked';
 'startstop' = true;


### PR DESCRIPTION
See #83. 

I suggest adding it into 16.10 as the problem is quite serious : without this, ncm-iptables lets you believe that your system is properly protected when it is not... For backward compatibility with previous version of the templates, the default remains not to manage the state of iptables and firewalld services (else there is the risk of breaking a system where the config is incorrect without side effect because the service is not active in fact).

Heavily tested at LAL.

Note that to be able to switch back to firewalld, in addition to this PR, https://github.com/quattor/configuration-modules-core/issues/962 should be fixed. But this should not delay merging this PR IMO, as it already fixes an important potential security problem.