### PR TITLE
Sl6.x: add new perl dependencies for Quattor development

### DIFF
--- a/rpms/quattor-development.pan
+++ b/rpms/quattor-development.pan
@@ -22,6 +22,8 @@ unique template rpms/quattor-development;
   pkg_repl('perl-Taint-Runtime');
   pkg_repl('perl-enum');
   pkg_repl('perl-XML-Simple');
+  pkg_repl('perl-Module-Load');
+  pkg_repl('perl-Perl-Critic');
 
   pkg_repl('rpmdevtools');
 

--- a/rpms/quattor-development.pan
+++ b/rpms/quattor-development.pan
@@ -24,6 +24,7 @@ unique template rpms/quattor-development;
   pkg_repl('perl-XML-Simple');
   pkg_repl('perl-Module-Load');
   pkg_repl('perl-Perl-Critic');
+  pkg_repl('perl-Parallel-ForkManager');
 
   pkg_repl('rpmdevtools');
 

--- a/rpms/quattor-development.pan
+++ b/rpms/quattor-development.pan
@@ -3,6 +3,7 @@ unique template rpms/quattor-development;
 '/software/packages' = {
   pkg_repl('perl-Template-Toolkit');
   pkg_repl('perl-Text-Autoformat');
+  pkg_repl('perl-Text-Diff');
   pkg_repl('perl-Text-Glob');
   pkg_repl('perl-Pod-POM');
   pkg_repl('perl-Test-Deep');


### PR DESCRIPTION
`perl-Module-Load`, `perl-Parallel-ForkManager`, `perl-Text-Diff` and `perl-Perl-Critic` added (required by some unit tests).