### PR TITLE
EL7: remove definition of Grub args

### DIFF
--- a/config/core/boot.pan
+++ b/config/core/boot.pan
@@ -1,7 +1,6 @@
 @{
-    Template listing boot options for all SL6 nodes.
+    Template listing boot options for all EL7 hosts.
 }
 
 unique template config/core/boot;
 
-"/software/components/grub/args" = "crashkernel=128M@16M nohz=off";


### PR DESCRIPTION
- ncm-grub doesn't support Grub2
- Actual value assigned is for EL6